### PR TITLE
Add VRAM cleanup in pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ python3 gradio_app.py \
   --low_vram_mode
 ```
 
+The shape pipelines automatically free GPU memory after each run when using CUDA,
+releasing VRAM for subsequent tasks.
+
 
 ## 🔗 BibTeX
 

--- a/hy3dshape/hy3dshape/pipelines.py
+++ b/hy3dshape/hy3dshape/pipelines.py
@@ -649,11 +649,15 @@ class Hunyuan3DDiTPipeline:
                     step_idx = i // getattr(self.scheduler, "order", 1)
                     callback(step_idx, t, outputs)
 
-        return self._export(
+        output = self._export(
             latents,
             output_type,
             box_v, mc_level, num_chunks, octree_resolution, mc_algo,
         )
+        self.maybe_free_model_hooks()
+        if self.device.type == "cuda":
+            torch.cuda.empty_cache()
+        return output
 
     def _export(
         self,
@@ -775,9 +779,13 @@ class Hunyuan3DDiTFlowMatchingPipeline(Hunyuan3DDiTPipeline):
                     step_idx = i // getattr(self.scheduler, "order", 1)
                     callback(step_idx, t, outputs)
 
-        return self._export(
+        output = self._export(
             latents,
             output_type,
             box_v, mc_level, num_chunks, octree_resolution, mc_algo,
             enable_pbar=enable_pbar,
         )
+        self.maybe_free_model_hooks()
+        if self.device.type == "cuda":
+            torch.cuda.empty_cache()
+        return output


### PR DESCRIPTION
## Summary
- clean up GPU memory in `Hunyuan3DDiTPipeline.__call__`
- clean up GPU memory in `Hunyuan3DDiTFlowMatchingPipeline.__call__`
- mention automatic VRAM release in README

## Testing
- `python -m py_compile hy3dshape/hy3dshape/pipelines.py`

------
https://chatgpt.com/codex/tasks/task_e_6859dd33dc9c832bacc6d141b76d45b7