### PR TITLE
Fix device handling in SelfAttnProcessor2_0

### DIFF
--- a/hy3dpaint/hunyuanpaintpbr/unet/attn_processor.py
+++ b/hy3dpaint/hunyuanpaintpbr/unet/attn_processor.py
@@ -687,7 +687,7 @@ class SelfAttnProcessor2_0(BaseAttnProcessor):
 
         # Device management (if needed)
         if multiple_devices:
-            device = torch.device("cuda:0") if token == "albedo" else torch.device("cuda:1")
+            device = hidden_states.device
             for attr in [f"to_q{token_suffix}", f"to_k{token_suffix}", f"to_v{token_suffix}", f"to_out{token_suffix}"]:
                 getattr(target, attr).to(device)
 
@@ -747,7 +747,7 @@ class SelfAttnProcessor2_0(BaseAttnProcessor):
         # Process each PBR setting
         results = []
         for token, pbr_hs in zip(self.pbr_setting, pbr_hidden_states):
-            processed_hs = rearrange(pbr_hs, "b n_pbrs n l c -> (b n_pbrs n) l c").to("cuda:0")
+            processed_hs = rearrange(pbr_hs, "b n_pbrs n l c -> (b n_pbrs n) l c").to(hidden_states.device)
             result = self.process_single(attn, processed_hs, None, attention_mask, temb, token, False)
             results.append(result)
 


### PR DESCRIPTION
## Summary
- remove hard-coded `cuda:0` and `cuda:1` device usage
- use tensor's current device so passing `--device cuda:1` works correctly

## Testing
- `python -m py_compile hy3dpaint/hunyuanpaintpbr/unet/attn_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_685ab8195f10832b9741e86524ca13ca